### PR TITLE
添加IEnumerable解析支持

### DIFF
--- a/NAutowired.Console.Test/TestClass/EnumerableMultipleImplementService.cs
+++ b/NAutowired.Console.Test/TestClass/EnumerableMultipleImplementService.cs
@@ -1,0 +1,23 @@
+﻿using NAutowired.Core.Attributes;
+using System.Collections.Generic;
+
+namespace NAutowired.Console.Test.TestClass
+{
+    [Service]
+    public class EnumerableMultipleImplementService
+    {
+        [Autowired]
+        private readonly IEnumerable<IMultipleImplement> multipleImplements;
+
+        public string SayHello()
+        {
+            string rtn = "";
+            foreach(var impl in multipleImplements)
+            {
+                rtn += impl.SayHello() + ";";
+            }
+            return rtn;
+        }
+
+    }
+}

--- a/NAutowired.Console.Test/TestClass/EnumerableMultipleImplementService.cs
+++ b/NAutowired.Console.Test/TestClass/EnumerableMultipleImplementService.cs
@@ -9,14 +9,9 @@ namespace NAutowired.Console.Test.TestClass
         [Autowired]
         private readonly IEnumerable<IMultipleImplement> multipleImplements;
 
-        public string SayHello()
+        public IEnumerable<IMultipleImplement> SayHello()
         {
-            string rtn = "";
-            foreach(var impl in multipleImplements)
-            {
-                rtn += impl.SayHello() + ";";
-            }
-            return rtn;
+            return multipleImplements;
         }
 
     }

--- a/NAutowired.Console.Test/UnitTest.cs
+++ b/NAutowired.Console.Test/UnitTest.cs
@@ -97,19 +97,6 @@ namespace NAutowired.Console.Test
             Assert.Equal(nameof(MultipleImplementFooService), instance.FooSayHello());
         }
 
-        //有多实现不再报错
-        ///// <summary>
-        ///// 当接口具有多个实现时，需要显示指定还原哪个实现
-        ///// </summary>
-        //[Fact]
-        //public void TestMultipleImplementImplicitResolve()
-        //{
-        //    Assert.Throws<UnableResolveDependencyException>(() =>
-        //    {
-        //        consoleHost.GetService<ImplicitMultipleImplementService>();
-        //    });
-        //}
-
         /// <summary>
         /// 单类多接口实现 还原
         /// </summary>
@@ -145,8 +132,10 @@ namespace NAutowired.Console.Test
         {
             var instance = consoleHost.GetService<EnumerableMultipleImplementService>();
             Assert.NotNull(instance);
-            Assert.Contains("MultipleImplementBarService", instance.SayHello());
-            Assert.Contains("MultipleImplementFooService", instance.SayHello());
+
+            var implements = instance.SayHello();
+            Assert.Contains(implements, i => i.GetType() == typeof(MultipleImplementBarService));
+            Assert.Contains(implements, i => i.GetType() == typeof(MultipleImplementFooService));
         }
     }
 }

--- a/NAutowired.Console.Test/UnitTest.cs
+++ b/NAutowired.Console.Test/UnitTest.cs
@@ -97,17 +97,18 @@ namespace NAutowired.Console.Test
             Assert.Equal(nameof(MultipleImplementFooService), instance.FooSayHello());
         }
 
-        /// <summary>
-        /// 当接口具有多个实现时，需要显示指定还原哪个实现
-        /// </summary>
-        [Fact]
-        public void TestMultipleImplementImplicitResolve()
-        {
-            Assert.Throws<UnableResolveDependencyException>(() =>
-            {
-                consoleHost.GetService<ImplicitMultipleImplementService>();
-            });
-        }
+        //有多实现不再报错
+        ///// <summary>
+        ///// 当接口具有多个实现时，需要显示指定还原哪个实现
+        ///// </summary>
+        //[Fact]
+        //public void TestMultipleImplementImplicitResolve()
+        //{
+        //    Assert.Throws<UnableResolveDependencyException>(() =>
+        //    {
+        //        consoleHost.GetService<ImplicitMultipleImplementService>();
+        //    });
+        //}
 
         /// <summary>
         /// 单类多接口实现 还原
@@ -135,5 +136,17 @@ namespace NAutowired.Console.Test
         //    Assert.NotNull(service.GetBarService());
         //    Assert.IsType<BarService>(service.GetBarService());
         //}
+
+        /// <summary>
+        /// 当接口具有多个实现时，可以注入集合
+        /// </summary>
+        [Fact]
+        public void TestMultipleImplementCollectionResolve()
+        {
+            var instance = consoleHost.GetService<EnumerableMultipleImplementService>();
+            Assert.NotNull(instance);
+            Assert.Contains("MultipleImplementBarService", instance.SayHello());
+            Assert.Contains("MultipleImplementFooService", instance.SayHello());
+        }
     }
 }

--- a/NAutowired.Core/Extensions/ServiceProviderExtension.cs
+++ b/NAutowired.Core/Extensions/ServiceProviderExtension.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NAutowired.Core.Extensions
+{
+    /// <summary>
+    /// 解析服务扩展类，从容器获取服务并解析其Autowired依赖。
+    /// </summary>
+    public static class ServiceProviderExtension
+    {
+        /// <summary>
+        /// 解析指定实例的Autowired依赖
+        /// </summary>
+        /// <param name="serviceProvider">服务提供器</param>
+        /// <param name="instance">已创建的服务实例</param>
+        public static void WithAutowired(this IServiceProvider serviceProvider, object instance)
+        {
+            NAutowired.Core.DependencyInjection.Resolve(serviceProvider, instance);
+        }
+
+        /// <summary>
+        /// 从容器获取服务并解析Autowired依赖
+        /// </summary>
+        /// <typeparam name="T">服务类型，可以为IEnumerable&lt;&gt;</typeparam>
+        /// <param name="serviceProvider"></param>
+        /// <returns></returns>
+        public static T GetServiceWithAutowired<T>(this IServiceProvider serviceProvider)
+        {
+            T instance = serviceProvider.GetRequiredService<T>();
+            NAutowired.Core.DependencyInjection.Resolve(serviceProvider, instance);
+            return instance;
+        }
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ public void ConfigureServices(IServiceCollection services) {
 public void ConfigureServices(IServiceCollection services) {
     //Add FooService to container.
     services.AddScoped<FooService>();
+    //Add IBarService implements to container.
+    services.AddScoped<IBarService, MyBarService1>();
+    services.AddScoped<IBarService, MyBarService2>();
 }
 ```
 ```csharp
@@ -55,6 +58,10 @@ public void ConfigureServices(IServiceCollection services) {
     //Use Autowired injection.
     [Autowired]
     private readonly FooService fooService;
+
+    //Also supports IEnumerable<T> injection.
+    [Autowired]
+    private readonly IEnumerable<IBarService> barServices;
 
     [HttpGet]
     public ActionResult<string> Get() {
@@ -213,6 +220,17 @@ class Program
   }
 ```
  `NAutowired` will automatically scan all classes under the assembly configured by the `AutoRegisterDependency(assemblyName)` method, and inject the class with the `[Service] [Repository] [Component] [ServiceFilter]` property into the container.
+ 
+ #### `NAutowired` provides `WithAutowired`、`GetServiceWithAutowired` extension methods，which can obtain services from containers and automatically resolve their `[Autowired]` dependencies. It's particularly convenient when you need to manually obtain services or resolve existing instances.
+```csharp
+services.AddSingleton(sp =>
+{
+    var foo = sp.GetServiceWithAutowired<IFooService>();
+    return foo.Create();
+});
+
+```
+
 
 
 ## Stargazers over time

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ public void ConfigureServices(IServiceCollection services) {
     public ActionResult<string> Get() {
       return fooService == null ? "failure" : "success";
     }
+
+    [HttpPost]
+    public ActionResult<string> Baz() {
+      return barServices?.Count > 0 ? "success" : "failure";
+    }
   }
 ```
 #### Use in `Filter`

--- a/README_CN.md
+++ b/README_CN.md
@@ -69,6 +69,11 @@ public void ConfigureServices(IServiceCollection services) {
     public ActionResult<string> Get() {
       return fooService == null ? "failure" : "success";
     }
+
+    [HttpPost]
+    public ActionResult<string> Baz() {
+      return barServices?.Count > 0 ? "success" : "failure";
+    }
   }
 ```
 #### 在`Filter`中使用`NAutowired`

--- a/README_CN.md
+++ b/README_CN.md
@@ -46,6 +46,9 @@ public void ConfigureServices(IServiceCollection services) {
     public void ConfigureServices(IServiceCollection services) {
       //将FooService加到容器
       services.AddScoped<FooService>();
+      //将多个IBarService实现加到容器
+      services.AddScoped<IBarService, MyBarService1>();
+      services.AddScoped<IBarService, MyBarService2>();
     }
   }
 ```
@@ -57,6 +60,10 @@ public void ConfigureServices(IServiceCollection services) {
     //使用Autowired Attribute注入实例
     [Autowired]
     private readonly FooService fooService;
+
+    //支持注入集合
+    [Autowired]
+    private readonly IEnumerable<IBarService> barServices;
 
     [HttpGet]
     public ActionResult<string> Get() {
@@ -215,6 +222,16 @@ class Program
 
 ```
 `NAutowired`会自动扫描`AutoRegisterDependency(assemblyNames)`方法配置的程序集下的所有类，并将具有`[Service] [Repository] [Component] [ServiceFilter]`特性的类注入到容器。
+
+#### `NAutowired`提供了`WithAutowired`、`GetServiceWithAutowired`扩展方法，可以从容器中获取服务，并自动解析其`[Autowired]`依赖。在需要手动获取服务或者解析现有实例时使用这些方法尤为方便。
+```csharp
+services.AddSingleton(sp =>
+{
+    var foo = sp.GetServiceWithAutowired<IFooService>();
+    return foo.Create();
+});
+
+```
 
 ## Stargazers over time
 


### PR DESCRIPTION
此PR是为了 #21 提出的增强功能

1. 添加了对IEnumerable<T>依赖的解析支持，注入T类型服务集合。
2. 添加扩展方法，方便手动从容器获取服务时的Autowired依赖解析。
3. 添加了测试方法。