### PR TITLE
解决接口依赖引起的循环引用问题

### DIFF
--- a/NAutowired.Console.Test/TestClass/CircularDependencyAInterfaceService.cs
+++ b/NAutowired.Console.Test/TestClass/CircularDependencyAInterfaceService.cs
@@ -1,0 +1,14 @@
+﻿using NAutowired.Core.Attributes;
+
+namespace NAutowired.Console.Test.TestClass
+{
+    [Service]
+    public class CircularDependencyAInterfaceService : IAService
+    {
+        [Autowired]
+        private readonly IBService bService;
+
+        public IBService GetCircularDependencyBService() { return bService; }
+
+    }
+}

--- a/NAutowired.Console.Test/TestClass/CircularDependencyBInterfaceService.cs
+++ b/NAutowired.Console.Test/TestClass/CircularDependencyBInterfaceService.cs
@@ -1,0 +1,13 @@
+﻿using NAutowired.Core.Attributes;
+
+namespace NAutowired.Console.Test.TestClass
+{
+    [Service]
+    public class CircularDependencyBInterfaceService : IBService
+    {
+        [Autowired]
+        private readonly IAService aService;
+
+        public IAService GetCircularDependencyAService() { return aService; }
+    }
+}

--- a/NAutowired.Console.Test/TestClass/IAService.cs
+++ b/NAutowired.Console.Test/TestClass/IAService.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NAutowired.Console.Test.TestClass
+{
+    public interface IAService
+    {
+    }
+}

--- a/NAutowired.Console.Test/TestClass/IBService.cs
+++ b/NAutowired.Console.Test/TestClass/IBService.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NAutowired.Console.Test.TestClass
+{
+    public interface IBService
+    {
+    }
+}

--- a/NAutowired.Console.Test/UnitTest.cs
+++ b/NAutowired.Console.Test/UnitTest.cs
@@ -63,6 +63,17 @@ namespace NAutowired.Console.Test
         }
 
         [Fact]
+        public void TestCircularInterfaceDependency()
+        {
+            var circularDependencyFooService = consoleHost.GetService<CircularDependencyBInterfaceService>();
+            Assert.NotNull(circularDependencyFooService);
+            Assert.NotNull(circularDependencyFooService.GetCircularDependencyAService());
+            var circularDependencyBarService = consoleHost.GetService<CircularDependencyAInterfaceService>();
+            Assert.NotNull(circularDependencyBarService);
+            Assert.NotNull(circularDependencyBarService.GetCircularDependencyBService());
+        }
+
+        [Fact]
         public void TestBaseAutowired()
         {
             var baseService = consoleHost.GetService<BaseService>();

--- a/NAutowired.Console/NAutowired.Console.csproj
+++ b/NAutowired.Console/NAutowired.Console.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\NAutowired.Core\NAutowired.Core.csproj" />
+    <PackageReference Include="NAutowired.Core" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/NAutowired.Console/NAutowired.Console.csproj
+++ b/NAutowired.Console/NAutowired.Console.csproj
@@ -27,14 +27,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NAutowired.Core" Version="2.2.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="..\LICENSE.txt">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NAutowired.Core\NAutowired.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/NAutowired.Core/DependencyInjection.cs
+++ b/NAutowired.Core/DependencyInjection.cs
@@ -97,7 +97,8 @@ namespace NAutowired.Core
         /// <returns></returns>
         private static object GetInstance(InstanceScopeModel instanceScopeModel, Type type)
         {
-            if (instanceScopeModel.Instance.GetType() == type)
+            if (type.IsInterface && type.IsAssignableFrom(instanceScopeModel.Instance.GetType()) ||
+                instanceScopeModel.Instance.GetType() == type)
             {
                 return instanceScopeModel.Instance;
             }


### PR DESCRIPTION
实际开发中采用面向接口编程。依赖类型声明为接口时，会出现循环引用导致堆栈溢出问题。添加了依赖树遍历时的接口类型判断。